### PR TITLE
[fix] Error handling for when the user doesn't pass any date in the /nuevos command

### DIFF
--- a/src/slash_command/mod.rs
+++ b/src/slash_command/mod.rs
@@ -66,6 +66,10 @@ pub fn slash_command_route(command: Form<ListNewsEmployeesCommand>) -> status::C
             ParseDateStrError::Interval(invalid) => {
                 status::Custom(Status::Ok, format!("El intervalo {} es", invalid))
             }
+            ParseDateStrError::NoDate => status::Custom(
+                Status::Ok,
+                "No se recibió fecha. Escribí /ayuda para ver opciones de formato.".to_string(),
+            ),
         },
     }
 }
@@ -74,7 +78,7 @@ pub fn slash_command_route(command: Form<ListNewsEmployeesCommand>) -> status::C
 pub fn help_command_route() -> status::Custom<String> {
     let help_message = "
                     - Para listar nuevos empleados dentro de un rango de fechas específico, escribí `/nuevos <fecha_inicio> <fecha_fin>`.\n\
-                    - Podés usar fechas completas (DD-MM-YYYY), mes y año (MM-YYYY) o sólo año (YYYY).";
+                    - Podés usar fechas completas (DD/MM/YYYY), mes y año (MM/YYYY) o sólo año (YYYY).";
 
     status::Custom(Status::Ok, help_message.to_string())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,4 +20,5 @@ pub enum ParseDateStrError {
     DatePart(String),
     Date(String),
     Interval(String),
+    NoDate,
 }

--- a/src/utils/parse_interval.rs
+++ b/src/utils/parse_interval.rs
@@ -13,9 +13,7 @@ pub fn parse_interval(
         .collect::<Vec<&str>>();
 
     match v.len() {
-        0 => {
-            Err(ParseDateStrError::NoDate)
-        }
+        0 => Err(ParseDateStrError::NoDate),
         1 => match (
             parse_date_str(v[0], DateRound::Floor),
             parse_date_str(v[0], DateRound::Ceil),

--- a/src/utils/parse_interval.rs
+++ b/src/utils/parse_interval.rs
@@ -14,10 +14,7 @@ pub fn parse_interval(
 
     match v.len() {
         0 => {
-            let today = Utc::now().naive_local();
-            let from = today.date().and_hms_opt(0, 0, 0).unwrap();
-            let to = today.date().and_hms_opt(23, 59, 59).unwrap();
-            Ok((from, to))
+            Err(ParseDateStrError::NoDate)
         }
         1 => match (
             parse_date_str(v[0], DateRound::Floor),

--- a/src/utils/parse_interval.rs
+++ b/src/utils/parse_interval.rs
@@ -43,18 +43,6 @@ mod test_parse_interval {
     use super::parse_interval;
 
     #[test]
-    fn should_return_today_tuple_with_empty_str() {
-        let today = Utc::now().naive_local();
-        let today_eod = today.date().and_hms_opt(23, 59, 59).unwrap();
-        let today_bod = today.date().and_hms_opt(0, 0, 0).unwrap();
-
-        let (from, to) = parse_interval("").unwrap();
-
-        assert_eq!(from, today_bod);
-        assert_eq!(to, today_eod);
-    }
-
-    #[test]
     fn should_return_from_to_today_tuple_with_one_date() {
         let param = "01/01/2021";
         let param_date = chrono::NaiveDate::from_ymd_opt(2021, 1, 1).unwrap();


### PR DESCRIPTION
 - Added the error `ParseDateStrError::NoDate`, which prompts the user to enter the '/ayuda' command to view formatting options.
 - Removed test `should_return_today_tuple_with_empty_str`.